### PR TITLE
support numeric ids

### DIFF
--- a/transport_id.go
+++ b/transport_id.go
@@ -1,0 +1,84 @@
+package jsonrpc2
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+)
+
+type idType int
+
+const (
+	idTypeNull idType = iota
+	idTypeString
+	idTypeNumber
+)
+
+// id represents a JSON-RPC 2.0 id. The zero value is an undefined id.
+type id struct {
+	value   string
+	ty      idType
+	defined bool
+}
+
+func newUndefinedID() id { return id{} }
+
+func newNullID() id {
+	return id{ty: idTypeNull, defined: true}
+}
+
+func newStringID(value string) id {
+	return id{value: value, ty: idTypeString, defined: true}
+}
+
+func newNumberID(value int64) id {
+	return id{value: strconv.FormatInt(value, 10), ty: idTypeNumber, defined: true}
+}
+
+func (v *id) IsNull() bool      { return v.ty == idTypeNull }
+func (v *id) IsString() bool    { return v.ty == idTypeString }
+func (v *id) IsNumber() bool    { return v.ty == idTypeNumber }
+func (v *id) IsUndefined() bool { return !v.defined }
+func (v *id) String() string    { return v.value }
+
+func (v *id) UnmarshalJSON(bb []byte) error {
+	v.defined = true
+
+	// Try unmarshaling an *int first. This covers null types
+	// and numeric IDs.
+	var numericVal *int64
+	if err := json.Unmarshal(bb, &numericVal); err == nil {
+		if numericVal == nil {
+			*v = newNullID()
+			return nil
+		}
+		*v = newNumberID(*numericVal)
+		return nil
+	}
+
+	// Fall back to string.
+	var stringVal string
+	if err := json.Unmarshal(bb, &stringVal); err == nil {
+		*v = newStringID(stringVal)
+		return nil
+	}
+
+	return fmt.Errorf("id must be string, number, or null")
+}
+
+func (v id) MarshalJSON() ([]byte, error) {
+	switch v.ty {
+	case idTypeNumber:
+		val, err := strconv.Atoi(v.value)
+		if err != nil {
+			return nil, fmt.Errorf("invalid numeric id: %w", err)
+		}
+		return json.Marshal(val)
+	case idTypeString:
+		return json.Marshal(v.value)
+	case idTypeNull:
+		return json.Marshal(nil)
+	default:
+		return nil, fmt.Errorf("unknown id type")
+	}
+}

--- a/transport_id_test.go
+++ b/transport_id_test.go
@@ -1,0 +1,73 @@
+package jsonrpc2
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_id_Unmarshal(t *testing.T) {
+	tt := []struct {
+		name   string
+		input  string
+		expect id
+	}{
+		{
+			name:   "null",
+			input:  `null`,
+			expect: newNullID(),
+		},
+		{
+			name:   "number",
+			input:  `12345`,
+			expect: newNumberID(12345),
+		},
+		{
+			name:   "string",
+			input:  `"hello"`,
+			expect: newStringID("hello"),
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			var actual id
+			err := json.Unmarshal([]byte(tc.input), &actual)
+			require.NoError(t, err)
+			require.Equal(t, actual, tc.expect)
+		})
+	}
+}
+
+func Test_id_Marshal(t *testing.T) {
+	tt := []struct {
+		name   string
+		input  id
+		expect string
+	}{
+		{
+			name:   "null",
+			input:  newNullID(),
+			expect: `null`,
+		},
+		{
+			name:   "number",
+			input:  newNumberID(12345),
+			expect: `12345`,
+		},
+		{
+			name:   "string",
+			input:  newStringID("hello"),
+			expect: `"hello"`,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			bb, err := json.Marshal(tc.input)
+			require.NoError(t, err)
+			require.JSONEq(t, tc.expect, string(bb))
+		})
+	}
+}


### PR DESCRIPTION
Introduces an internal `id` string type that retains whether it was unmarshaled from undefined (for notifications), null, string, or a number. The type needs to be retained so the response is formed with the same input that was received. 
 
Closes #2.

Tested with the websocket example:

```
$ ws-client ws://localhost:8080
connected to  ws://localhost:8080
[17:19] » {"jsonrpc": "2.0", "method": "sum", "params": [1,2,3], "id": "abc"}
[17:19] « {"jsonrpc":"2.0","result":6,"id":"abc"}

[17:19] » {"jsonrpc": "2.0", "method": "sum", "params": [1,2,3], "id": 12345}
[17:19] « {"jsonrpc":"2.0","result":6,"id":12345}

[17:19] » {"jsonrpc": "2.0", "method": "sum", "params": [1,2,3], "id": null}
[17:19] « {"jsonrpc":"2.0","result":6,"id":null}
```

cc @jdbaldry 